### PR TITLE
fix for iOS8+ deprecated setStatusBarHidden

### DIFF
--- a/Demo Storyboard/LGSideMenuControllerDemo/AppDelegate.h
+++ b/Demo Storyboard/LGSideMenuControllerDemo/AppDelegate.h
@@ -10,7 +10,7 @@
 
 #warning CHOOSE TYPE 1 .. 5
 
-#define TYPE 1
+#define TYPE 4
 
 #define kMainViewController (MainViewController *)[[(AppDelegate *)[[UIApplication sharedApplication] delegate] window] rootViewController]
 #define kNavigationController (UINavigationController *)[(MainViewController *)[[(AppDelegate *)[[UIApplication sharedApplication] delegate] window] rootViewController] rootViewController]

--- a/Demo Storyboard/LGSideMenuControllerDemo/Info.plist
+++ b/Demo Storyboard/LGSideMenuControllerDemo/Info.plist
@@ -42,6 +42,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
+	<true/>
 </dict>
 </plist>

--- a/Demo Storyboard/Podfile.lock
+++ b/Demo Storyboard/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - LGSideMenuController (1.0.2)
+  - LGSideMenuController (1.0.3)
 
 DEPENDENCIES:
   - LGSideMenuController (from `../`)
@@ -9,6 +9,6 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  LGSideMenuController: e3105c0fe8ef68475fd4d8695913c0bcb8759630
+  LGSideMenuController: 565ca94043437552cda5a88384e0a481169c3f32
 
 COCOAPODS: 0.38.2

--- a/Demo/LGSideMenuControllerDemo/AppDelegate.h
+++ b/Demo/LGSideMenuControllerDemo/AppDelegate.h
@@ -11,7 +11,7 @@
 
 #warning CHOOSE TYPE 1 .. 5
 
-#define TYPE 1
+#define TYPE 4
 
 #define kMainViewController [(AppDelegate *)[[UIApplication sharedApplication] delegate] mainViewController]
 #define kNavigationController (UINavigationController *)[[(AppDelegate *)[[UIApplication sharedApplication] delegate] mainViewController] rootViewController]

--- a/Demo/LGSideMenuControllerDemo/Info.plist
+++ b/Demo/LGSideMenuControllerDemo/Info.plist
@@ -42,6 +42,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
+	<true/>
 </dict>
 </plist>

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - LGSideMenuController (1.0.0)
+  - LGSideMenuController (1.0.3)
 
 DEPENDENCIES:
   - LGSideMenuController (from `../`)
@@ -9,6 +9,6 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  LGSideMenuController: d1f235f481e13fdffb10966f02e4465fedf3fe60
+  LGSideMenuController: 565ca94043437552cda5a88384e0a481169c3f32
 
-COCOAPODS: 0.37.2
+COCOAPODS: 0.38.2

--- a/LGSideMenuController/LGSideMenuController.m
+++ b/LGSideMenuController/LGSideMenuController.m
@@ -135,6 +135,7 @@
 @property (strong, nonatomic) UIView *rightViewStyleView;
 
 @property (assign, nonatomic) BOOL savedStatusBarHidden;
+@property (assign, nonatomic) BOOL hideStatusBar;
 
 @property (strong, nonatomic) NSNumber *leftViewGestireStartX;
 @property (strong, nonatomic) NSNumber *rightViewGestireStartX;
@@ -285,6 +286,10 @@
         [self rightViewLayoutInvalidateWithPercentage:(self.isRightViewShowing ? 1.f : 0.f)];
         [self hiddensInvalidateWithDelay:(appeared ? 0.25 : 0.0)];
     }
+}
+
+- (BOOL)prefersStatusBarHidden {
+    return self.hideStatusBar;
 }
 
 #pragma mark -
@@ -1150,7 +1155,12 @@
         {
             [_rootVC removeFromParentViewController];
             
-            [[UIApplication sharedApplication] setStatusBarHidden:YES withAnimation:UIStatusBarAnimationFade];
+            if (kLGSideMenuSystemVersion >= 8.0){
+                self.hideStatusBar = YES;
+                [self setNeedsStatusBarAppearanceUpdate];
+            }else{
+                [[UIApplication sharedApplication] setStatusBarHidden:YES withAnimation:UIStatusBarAnimationFade];
+            }
         }
     }
     
@@ -1215,7 +1225,12 @@
     {
         [self addChildViewController:_rootVC];
         
-        [[UIApplication sharedApplication] setStatusBarHidden:NO withAnimation:UIStatusBarAnimationFade];
+        if (kLGSideMenuSystemVersion >= 8.0){
+            self.hideStatusBar = NO;
+            [self setNeedsStatusBarAppearanceUpdate];
+        }else{
+            [[UIApplication sharedApplication] setStatusBarHidden:NO withAnimation:UIStatusBarAnimationFade];
+        }
     }
     
     [[NSNotificationCenter defaultCenter] postNotificationName:kLGSideMenuControllerWillDismissLeftViewNotification object:self userInfo:nil];
@@ -1303,8 +1318,13 @@
         if (!kLGSideMenuStatusBarHidden && !kLGSideMenuIsRightViewStatusBarVisible)
         {
             [_rootVC removeFromParentViewController];
-            
-            [[UIApplication sharedApplication] setStatusBarHidden:YES withAnimation:UIStatusBarAnimationFade];
+
+            if (kLGSideMenuSystemVersion >= 8.0){
+                self.hideStatusBar = YES;
+                [self setNeedsStatusBarAppearanceUpdate];
+            }else{
+                [[UIApplication sharedApplication] setStatusBarHidden:YES withAnimation:UIStatusBarAnimationFade];
+            }
         }
     }
     
@@ -1368,8 +1388,13 @@
     if (kLGSideMenuSystemVersion >= 7.0 && !_savedStatusBarHidden && kLGSideMenuStatusBarHidden && !self.isLeftViewShowing)
     {
         [self addChildViewController:_rootVC];
-        
-        [[UIApplication sharedApplication] setStatusBarHidden:NO withAnimation:UIStatusBarAnimationFade];
+
+        if (kLGSideMenuSystemVersion >= 8.0){
+            self.hideStatusBar = NO;
+            [self setNeedsStatusBarAppearanceUpdate];
+        }else{
+            [[UIApplication sharedApplication] setStatusBarHidden:NO withAnimation:UIStatusBarAnimationFade];
+        }
     }
     
     [[NSNotificationCenter defaultCenter] postNotificationName:kLGSideMenuControllerWillDismissRightViewNotification object:self userInfo:nil];


### PR DESCRIPTION
Make sure to use "View controller-based status bar appearance" on iOS8 and later.
(Leave the setting UIViewControllerBasedStatusBarAppearance out of the plist or set it to YES)