### PR TITLE
Fixes issue when using framework from within a Swift project

### DIFF
--- a/Framework/LGSideMenuControllerFramework.xcodeproj/project.pbxproj
+++ b/Framework/LGSideMenuControllerFramework.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		4AF139C41BF384DA0037B073 /* LGSideMenuControllerFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AF139C31BF384DA0037B073 /* LGSideMenuControllerFramework.h */; };
+		4AF139C41BF384DA0037B073 /* LGSideMenuControllerFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AF139C31BF384DA0037B073 /* LGSideMenuControllerFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4AF13A161BF395900037B073 /* LGSideMenuController.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AF13A141BF395900037B073 /* LGSideMenuController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4AF13A171BF395900037B073 /* LGSideMenuController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AF13A151BF395900037B073 /* LGSideMenuController.m */; };
 /* End PBXBuildFile section */


### PR DESCRIPTION
My project is using Swift exclusively, and using Xcode 7.1, I was not able to `import LGSideMenuController`, as this resulted in a "no such module" error.  When I attempted `import LGSideMenuControllerFramework`, I got a "could not build objective-c module" error.

Making the LGSideMenuControllerFramework.h file resolved the issue.