### PR TITLE
Fixed a bug where pan gesture would disable UITableView swipe to dele…

### DIFF
--- a/LGSideMenuController/LGSideMenuController.m
+++ b/LGSideMenuController/LGSideMenuController.m
@@ -294,6 +294,7 @@
     [self.view addGestureRecognizer:tapGesture];
 
     _panGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(panGesture:)];
+    _panGesture.delegate = self;
     _panGesture.minimumNumberOfTouches = 1;
     _panGesture.maximumNumberOfTouches = 1;
     _panGesture.cancelsTouchesInView = YES;
@@ -1769,7 +1770,15 @@
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
 {
-    return ([touch.view isEqual:_rootViewCoverViewForLeftView] || [touch.view isEqual:_rootViewCoverViewForRightView]);
+    if ([gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]]) {
+        return YES;
+    } else {
+        return ([touch.view isEqual:_rootViewCoverViewForLeftView] || [touch.view isEqual:_rootViewCoverViewForRightView]);
+    }
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    return [gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]];
 }
 
 #pragma mark - Support


### PR DESCRIPTION
…te gesture even when `gesturesCancelsTouchesInView` was set to `false`. This closes  #12.

This also fixes the issue where user can press and hold a button then drag down and then back up to the button without picking up their fingers will trigger action was broken by pan gesture. This restored the standard UIButtons behavior.