### PR TITLE
Fix gesture BUG

### DIFF
--- a/LGSideMenuController/LGSideMenuController.h
+++ b/LGSideMenuController/LGSideMenuController.h
@@ -96,6 +96,8 @@ LGSideMenuPresentationStyle;
 @property (assign, nonatomic, getter=isRightViewSwipeGestureEnabled) IBInspectable BOOL rightViewSwipeGestureEnabled;
 /** Default is YES */
 @property (assign, nonatomic, getter=isGesturesCancelsTouchesInView) IBInspectable BOOL gesturesCancelsTouchesInView;
+/** Default enabled is YES*/
+@property (strong, nonatomic) UIPanGestureRecognizer *panGesture;
 
 /**
  Color that hides root view, when left view is showing

--- a/LGSideMenuController/LGSideMenuController.m
+++ b/LGSideMenuController/LGSideMenuController.m
@@ -143,8 +143,6 @@
 @property (assign, nonatomic, getter=isLeftViewShowingBeforeGesture) BOOL leftViewShowingBeforeGesture;
 @property (assign, nonatomic, getter=isRightViewShowingBeforeGesture) BOOL rightViewShowingBeforeGesture;
 
-@property (strong, nonatomic) UIPanGestureRecognizer *panGesture;
-
 @end
 
 @implementation LGSideMenuController


### PR DESCRIPTION
when content view has sub view has some BUG. with `UITableView`, when
swipe tableViewCell, the edit style not work. because the `panGesture`
in sideMenu hide this. i try to do something in `-
(BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
shouldReceiveTouch:(UITouch *)touch` but not work. so, i change the
panGesture property to .h file. i can control the gesture.enabled
property to Fix my bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/friend-lga/lgsidemenucontroller/46)
<!-- Reviewable:end -->
