### PR TITLE
Renames framework target to remove the Framework suffix.

### DIFF
--- a/Framework/LGSideMenuController.xcodeproj/project.pbxproj
+++ b/Framework/LGSideMenuController.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		4AF139C01BF384DA0037B073 /* LGSideMenuControllerFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LGSideMenuControllerFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4AF139C01BF384DA0037B073 /* LGSideMenuController.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LGSideMenuController.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4AF139C31BF384DA0037B073 /* LGSideMenuControllerFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LGSideMenuControllerFramework.h; sourceTree = "<group>"; };
 		4AF139C51BF384DA0037B073 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4AF13A141BF395900037B073 /* LGSideMenuController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGSideMenuController.h; sourceTree = "<group>"; };
@@ -47,7 +47,7 @@
 		4AF139C11BF384DA0037B073 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				4AF139C01BF384DA0037B073 /* LGSideMenuControllerFramework.framework */,
+				4AF139C01BF384DA0037B073 /* LGSideMenuController.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -89,9 +89,9 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		4AF139BF1BF384DA0037B073 /* LGSideMenuControllerFramework */ = {
+		4AF139BF1BF384DA0037B073 /* LGSideMenuController */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 4AF139C81BF384DA0037B073 /* Build configuration list for PBXNativeTarget "LGSideMenuControllerFramework" */;
+			buildConfigurationList = 4AF139C81BF384DA0037B073 /* Build configuration list for PBXNativeTarget "LGSideMenuController" */;
 			buildPhases = (
 				4AF139BB1BF384DA0037B073 /* Sources */,
 				4AF139BC1BF384DA0037B073 /* Frameworks */,
@@ -102,9 +102,9 @@
 			);
 			dependencies = (
 			);
-			name = LGSideMenuControllerFramework;
+			name = LGSideMenuController;
 			productName = LGSideMenuControllerFramework;
-			productReference = 4AF139C01BF384DA0037B073 /* LGSideMenuControllerFramework.framework */;
+			productReference = 4AF139C01BF384DA0037B073 /* LGSideMenuController.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -121,7 +121,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 4AF139BA1BF384DA0037B073 /* Build configuration list for PBXProject "LGSideMenuControllerFramework" */;
+			buildConfigurationList = 4AF139BA1BF384DA0037B073 /* Build configuration list for PBXProject "LGSideMenuController" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
@@ -133,7 +133,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				4AF139BF1BF384DA0037B073 /* LGSideMenuControllerFramework */,
+				4AF139BF1BF384DA0037B073 /* LGSideMenuController */,
 			);
 		};
 /* End PBXProject section */
@@ -288,7 +288,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		4AF139BA1BF384DA0037B073 /* Build configuration list for PBXProject "LGSideMenuControllerFramework" */ = {
+		4AF139BA1BF384DA0037B073 /* Build configuration list for PBXProject "LGSideMenuController" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				4AF139C61BF384DA0037B073 /* Debug */,
@@ -297,7 +297,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		4AF139C81BF384DA0037B073 /* Build configuration list for PBXNativeTarget "LGSideMenuControllerFramework" */ = {
+		4AF139C81BF384DA0037B073 /* Build configuration list for PBXNativeTarget "LGSideMenuController" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				4AF139C91BF384DA0037B073 /* Debug */,

--- a/Framework/LGSideMenuController.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Framework/LGSideMenuController.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:LGSideMenuControllerFramework.xcodeproj">
+      location = "self:/Users/craig/projects/LGSideMenuController/Framework/LGSideMenuController.xcodeproj">
    </FileRef>
 </Workspace>

--- a/Framework/LGSideMenuController.xcodeproj/xcshareddata/xcschemes/LGSideMenuControllerFramework.xcscheme
+++ b/Framework/LGSideMenuController.xcodeproj/xcshareddata/xcschemes/LGSideMenuControllerFramework.xcscheme
@@ -15,9 +15,9 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "4AF139BF1BF384DA0037B073"
-               BuildableName = "LGSideMenuControllerFramework.framework"
-               BlueprintName = "LGSideMenuControllerFramework"
-               ReferencedContainer = "container:LGSideMenuControllerFramework.xcodeproj">
+               BuildableName = "LGSideMenuController.framework"
+               BlueprintName = "LGSideMenuController"
+               ReferencedContainer = "container:LGSideMenuController.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -46,9 +46,9 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4AF139BF1BF384DA0037B073"
-            BuildableName = "LGSideMenuControllerFramework.framework"
-            BlueprintName = "LGSideMenuControllerFramework"
-            ReferencedContainer = "container:LGSideMenuControllerFramework.xcodeproj">
+            BuildableName = "LGSideMenuController.framework"
+            BlueprintName = "LGSideMenuController"
+            ReferencedContainer = "container:LGSideMenuController.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
       <AdditionalOptions>
@@ -64,9 +64,9 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4AF139BF1BF384DA0037B073"
-            BuildableName = "LGSideMenuControllerFramework.framework"
-            BlueprintName = "LGSideMenuControllerFramework"
-            ReferencedContainer = "container:LGSideMenuControllerFramework.xcodeproj">
+            BuildableName = "LGSideMenuController.framework"
+            BlueprintName = "LGSideMenuController"
+            ReferencedContainer = "container:LGSideMenuController.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
    </ProfileAction>


### PR DESCRIPTION
This enables you to use the framework in a Swift target - discussed further in #71 