### PR TITLE
remove viewsHierarchyValidate call

### DIFF
--- a/LGSideMenuController/LGSideMenuController.m
+++ b/LGSideMenuController/LGSideMenuController.m
@@ -523,8 +523,6 @@ rightViewBackgroundImageFinalScale = _rightViewBackgroundImageFinalScale;
     [self leftViewsValidate];
     [self rightViewsValidate];
 
-    [self viewsHierarchyValidate];
-
     [self rootViewsFramesValidate];
     [self leftViewsFramesValidate];
     [self rightViewsFramesValidate];


### PR DESCRIPTION
updateLayoutsAndStylesWithDelay calls viewsHierarchyValidate which cause the view to be removed from it's superview and in fact all VCs (root, left, right) called viewDidAppear: again 