### PR TITLE
Setting up defaults and LGSideMenuSegue initialization moved from awakeFromNib to viewDidLoad

### DIFF
--- a/LGSideMenuController/LGSideMenuController.m
+++ b/LGSideMenuController/LGSideMenuController.m
@@ -263,22 +263,23 @@ rightViewBackgroundImageFinalScale = _rightViewBackgroundImageFinalScale;
     return self;
 }
 
-- (void)awakeFromNib {
-    [super awakeFromNib];
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
     [self setupDefaults];
-
+    
     // Try to initialize left and right view controllers from storyboard by segues
     if (self.storyboard) {
         @try {
             [self performSegueWithIdentifier:LGSideMenuSegueRootIdentifier sender:nil];
         }
         @catch (NSException *exception) {}
-
+        
         @try {
             [self performSegueWithIdentifier:LGSideMenuSegueLeftIdentifier sender:nil];
         }
         @catch (NSException *exception) {}
-
+        
         @try {
             [self performSegueWithIdentifier:LGSideMenuSegueRightIdentifier sender:nil];
         }


### PR DESCRIPTION
The initialization of segues inside awakeFromNib causes the breaking the whole application's initialization lifecycle because of the execution of viewDidLoad methods of Base and both Left/Right controllers before execution of application's delegate didFinishLaunchingWithOptions

Steps to reproduce:
1. Integrate Firebase and Firebase Database to the app
2. Add Firebase initialization to didFinishLaunchingWithOptions (according to Firebase documentation)
3. Add accessing to Firebase Realtime Database functionality inside viewDidLoad method of Left or Right menu controller
4. Run