### PR TITLE
Do not reveal the side panel if user is scrolling vertically

### DIFF
--- a/LGSideMenuController/Extensions/LGSideMenuController+GesturesHandler.swift
+++ b/LGSideMenuController/Extensions/LGSideMenuController+GesturesHandler.swift
@@ -110,9 +110,6 @@ extension LGSideMenuController {
 
         let location = gesture.location(in: self.view)
         let velocity = gesture.velocity(in: self.view)
-        
-        // If user is scrolling vertically, do not handle the gesture
-        if abs(velocity.y) > abs(velocity.x) { return }
 
         if self.isLeftViewVisibilityStable,
            gesture.state == .began || gesture.state == .changed {
@@ -123,7 +120,7 @@ extension LGSideMenuController {
                 if self.isLeftViewShowing {
                     self.hideLeftViewPrepare()
                 }
-                else {
+                else if abs(velocity.x) > abs(velocity.y) {
                     self.showLeftViewPrepare(updateStatusBar: true)
                 }
             }
@@ -181,9 +178,6 @@ extension LGSideMenuController {
         let location = gesture.location(in: self.view)
         let velocity = gesture.velocity(in: self.view)
         
-        // If user is scrolling vertically, do not handle the gesture
-        if abs(velocity.y) > abs(velocity.x) { return }
-
         if self.isRightViewVisibilityStable,
            gesture.state == .began || gesture.state == .changed {
             if self.isRightViewShowing ? velocity.x > 0.0 : velocity.x < 0.0 {
@@ -193,7 +187,7 @@ extension LGSideMenuController {
                 if self.isRightViewShowing {
                     self.hideRightViewPrepare()
                 }
-                else {
+                else if abs(velocity.x) > abs(velocity.y) {
                     self.showRightViewPrepare(updateStatusBar: true)
                 }
             }

--- a/LGSideMenuController/Extensions/LGSideMenuController+GesturesHandler.swift
+++ b/LGSideMenuController/Extensions/LGSideMenuController+GesturesHandler.swift
@@ -110,6 +110,9 @@ extension LGSideMenuController {
 
         let location = gesture.location(in: self.view)
         let velocity = gesture.velocity(in: self.view)
+        
+        // If user is scrolling vertically, do not handle the gesture
+        if abs(velocity.y) > abs(velocity.x) { return }
 
         if self.isLeftViewVisibilityStable,
            gesture.state == .began || gesture.state == .changed {
@@ -177,6 +180,9 @@ extension LGSideMenuController {
 
         let location = gesture.location(in: self.view)
         let velocity = gesture.velocity(in: self.view)
+        
+        // If user is scrolling vertically, do not handle the gesture
+        if abs(velocity.y) > abs(velocity.x) { return }
 
         if self.isRightViewVisibilityStable,
            gesture.state == .began || gesture.state == .changed {


### PR DESCRIPTION
Hi, thanks for the great library!

In my app, I find that sometime scrolling the content on the right edge might accidentally reveal the right side panel. I believe the side panel is usually revealed by swiping left or right and hence it should not be shown when user is scrolling vertically.